### PR TITLE
fix: avoid committing offset on error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "cached"
-version = "0.54.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9718806c4a2fe9e8a56fd736f97b340dd10ed1be8ed733ed50449f351dc33cae"
+checksum = "b0839c297f8783316fcca9d90344424e968395413f0662a5481f79c6648bbc14"
 dependencies = [
  "ahash",
  "async-trait",
@@ -681,16 +681,16 @@ dependencies = [
  "futures",
  "hashbrown 0.14.5",
  "once_cell",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "web-time",
 ]
 
 [[package]]
 name = "cached_proc_macro"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f42a145ed2d10dce2191e1dcf30cfccfea9026660e143662ba5eec4017d5daa"
+checksum = "673992d934f0711b68ebb3e1b79cdc4be31634b37c98f26867ced0438ca5c603"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -739,15 +739,6 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -2561,7 +2552,6 @@ version = "4.8.0+2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced38182dc436b3d9df0c77976f37a67134df26b050df1f0006688e46fc4c8be"
 dependencies = [
- "cmake",
  "libc",
  "libz-sys",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ httpmock = "0.7.0"
 lazy_static = "1.5.0"
 oxigraph = "0.4.9"
 prometheus = "0.14.0"
-rdkafka = { version = "0.37.0", features = ["cmake-build"] }
+rdkafka = "0.37.0"
 reqwest = { version = "0.12.15", features = ["blocking", "json"] }
 schema_registry_converter = { version = "4.4.0", features = ["avro", "blocking"] }
 serde = "1.0.219"

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -149,6 +149,10 @@ async fn receive_message(
         Ok(_) => {
             tracing::info!(elapsed_millis, "message handled successfully");
             PROCESSED_MESSAGES.with_label_values(&["success"]).inc();
+
+            if let Err(e) = consumer.store_offset_from_message(&message) {
+                tracing::warn!(error = e.to_string(), "failed to store offset");
+            };
         }
         Err(e) => {
             tracing::error!(
@@ -160,9 +164,6 @@ async fn receive_message(
         }
     };
     PROCESSING_TIME.observe(elapsed_millis as f64 / 1000.0);
-    if let Err(e) = consumer.store_offset_from_message(&message) {
-        tracing::warn!(error = e.to_string(), "failed to store offset");
-    };
 }
 
 pub async fn handle_message(


### PR DESCRIPTION
Jf. eksempel frå biblioteket (rdkafka) om at-least-once message delivery. 

https://github.com/fede1024/rust-rdkafka/blob/master/examples/at_least_once.rs

I applikasjonen blir offset satt uavhengig av utfall av prosessering, sånn eg ser det. Men det kan vere ein årsak til det? fdk-mqa-scoring-service og fdk-mqa-scoring-api toler retries (idempotent)...