### PR TITLE
fix: memory growth attempt

### DIFF
--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -7,7 +7,7 @@ use apache_avro::schema::Name;
 use lazy_static::lazy_static;
 use oxigraph::store::Store;
 use rdkafka::{
-    config::{ClientConfig},
+    config::ClientConfig,
     consumer::stream_consumer::StreamConsumer,
     consumer::Consumer,
     error::KafkaError,
@@ -68,7 +68,7 @@ pub fn create_consumer() -> Result<StreamConsumer, KafkaError> {
         .set("auto.offset.reset", "beginning")
         .set("api.version.request", "false")
         .set("security.protocol", "plaintext")
-        .set("max.partition.fetch.bytes", "1048576")
+        .set("max.partition.fetch.bytes", "2097152")
         .create()?;
     consumer.subscribe(&[&INPUT_TOPIC])?;
     Ok(consumer)
@@ -96,11 +96,12 @@ pub async fn run_async_processor(worker_id: usize, sr_settings: SrSettings) -> R
     let producer = create_producer()?;
     let mut encoder = AvroEncoder::new(sr_settings.clone());
     let mut decoder = AvroDecoder::new(sr_settings);
-    let input_store = Store::new()?;
-    let output_store = Store::new()?;
 
     tracing::info!(worker_id, "listening for messages");
     loop {
+        let input_store = Store::new()?;
+        let output_store = Store::new()?;
+
         let message = consumer.recv().await?;
         let span = tracing::span!(
             Level::INFO,
@@ -197,6 +198,7 @@ pub async fn handle_message(
 
             let record: FutureRecord<String, Vec<u8>> =
                 FutureRecord::to(&OUTPUT_TOPIC).key(&key).payload(&encoded);
+
             producer
                 .send(record, Duration::from_secs(0))
                 .await
@@ -243,7 +245,8 @@ async fn handle_dataset_event(
     match event.event_type {
         DatasetEventType::DatasetHarvested => {
             let graph =
-                parse_rdf_graph_and_calculate_metrics(input_store, output_store, event.graph).await?;
+                parse_rdf_graph_and_calculate_metrics(input_store, output_store, event.graph)
+                    .await?;
             Ok(MqaEvent {
                 event_type: MQAEventType::PropertiesChecked,
                 fdk_id: event.fdk_id,

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -68,7 +68,7 @@ pub fn create_consumer() -> Result<StreamConsumer, KafkaError> {
         .set("auto.offset.reset", "beginning")
         .set("api.version.request", "false")
         .set("security.protocol", "plaintext")
-        .set("max.partition.fetch.bytes", "2097152")
+        .set("max.partition.fetch.bytes", "1048576")
         .create()?;
     consumer.subscribe(&[&INPUT_TOPIC])?;
     Ok(consumer)
@@ -96,12 +96,11 @@ pub async fn run_async_processor(worker_id: usize, sr_settings: SrSettings) -> R
     let producer = create_producer()?;
     let mut encoder = AvroEncoder::new(sr_settings.clone());
     let mut decoder = AvroDecoder::new(sr_settings);
-    
+    let input_store = Store::new()?;
+    let output_store = Store::new()?;
+
     tracing::info!(worker_id, "listening for messages");
     loop {
-        let input_store = Store::new()?;
-        let output_store = Store::new()?;
-        
         let message = consumer.recv().await?;
         let span = tracing::span!(
             Level::INFO,

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -96,11 +96,12 @@ pub async fn run_async_processor(worker_id: usize, sr_settings: SrSettings) -> R
     let producer = create_producer()?;
     let mut encoder = AvroEncoder::new(sr_settings.clone());
     let mut decoder = AvroDecoder::new(sr_settings);
-    let input_store = Store::new()?;
-    let output_store = Store::new()?;
-
+    
     tracing::info!(worker_id, "listening for messages");
     loop {
+        let input_store = Store::new()?;
+        let output_store = Store::new()?;
+        
         let message = consumer.recv().await?;
         let span = tracing::span!(
             Level::INFO,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -21,6 +21,8 @@ pub async fn parse_rdf_graph_and_calculate_metrics(
     output_store: &Store,
     graph: String,
 ) -> Result<String, Error> {
+    input_store.clear()?;
+    output_store.clear()?;
     parse_turtle(input_store, graph)?;
     let dataset_node = get_dataset_node(input_store).ok_or("Dataset node not found in graph")?;
     let _ = calculate_metrics(dataset_node.as_ref(), input_store, output_store).await;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -21,8 +21,6 @@ pub async fn parse_rdf_graph_and_calculate_metrics(
     output_store: &Store,
     graph: String,
 ) -> Result<String, Error> {
-    input_store.clear()?;
-    output_store.clear()?;
     parse_turtle(input_store, graph)?;
     let dataset_node = get_dataset_node(input_store).ok_or("Dataset node not found in graph")?;
     let _ = calculate_metrics(dataset_node.as_ref(), input_store, output_store).await;


### PR DESCRIPTION
Feilsøking. Tanken her er at når det blir køyrt Clear på Store mellom kvar melding, som i dag, vil Store alltid ta like stor plass i minne som den største meldingen (grafen) den har mottatt, og når ein multipliserer det med 4 Workers så kan det vere ei forklaring. Ved å opprette ny Store for kvar melding for kvar Worker vil ein unngå det, men får kanskje andre problemer. Eit alternativ er som alltid å tildele enno meir minne.

Oppdatering: Etter å ha profilert/instrumentert applikasjonen lokalt, meiner eg at dette er (den viktigaste) årsaken til løpsk minnebruk.